### PR TITLE
WIP: Feat: add a pre verified create account flow to support fifthtry.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Authentication for sites and applications in fastn app ecosystem.
 
 ## UI Storybook
 
-All lets-talk UIs are developed using storybook.
+All lets-auth UIs are developed using storybook.
 
 Run `fastn` service using `run-ui` alias:
 

--- a/email-auth-provider/src/handlers/set_password.rs
+++ b/email-auth-provider/src/handlers/set_password.rs
@@ -4,59 +4,39 @@ pub fn set_password(
     mut conn: ft_sdk::Connection,
     ft_sdk::Required(new_password): ft_sdk::Required<"new-password">,
     ft_sdk::Required(new_password2): ft_sdk::Required<"new-password2">,
-    ft_sdk::Query(code): ft_sdk::Query<"code">,
-    ft_sdk::Query(spr): ft_sdk::Query<"spr">,
-    ft_sdk::Query(email): ft_sdk::Query<"email">,
+    ft_sdk::Query(code): ft_sdk::Query<"code", Option<String>>,
+    ft_sdk::Query(email): ft_sdk::Query<"email", Option<String>>,
     ft_sdk::Query(next): ft_sdk::Query<"next", Option<String>>,
     host: ft_sdk::Host,
     app_url: ft_sdk::AppUrl,
+    scheme: crate::HTTPSScheme,
+    sid: ft_sdk::Cookie<{ ft_sdk::auth::SESSION_KEY }>,
     ft_sdk::Config(config): ft_sdk::Config<crate::Config>,
 ) -> ft_sdk::form::Result {
     validate_email_and_password(&email, &new_password, &new_password2)?;
 
     let next = next.unwrap_or_else(|| "/".to_string());
 
-    let (user_id, data) = match ft_sdk::auth::provider::user_data_by_custom_attribute(
-        &mut conn,
-        email_auth::PROVIDER_ID,
-        email_auth::PASSWORD_RESET_CODE_KEY,
-        &code,
-    ) {
-        Ok(value) => value,
-        Err(ft_sdk::auth::UserDataError::NoDataFound) => return ft_sdk::form::redirect(next),
-        Err(e) => return Err(e.into()),
-    };
+    let (user_id, data) = get_user(&mut conn, sid, code)?;
 
-    let sent_at = data
-        .get_custom(email_auth::PASSWORD_RESET_CODE_SENT_AT)
-        .expect("PASSWORD_RESET_CODE_SENT_AT should exists if the account was found");
-    let sent_at = chrono::DateTime::from_timestamp_nanos(sent_at);
+    let sent_at = data.get_custom(email_auth::PASSWORD_RESET_CODE_SENT_AT);
 
-    if key_expired(sent_at) {
-        let reset_link = email_auth::handlers::forgot_password::generate_new_reset_key(
-            data.clone(),
-            &user_id,
-            &email,
-            spr,
-            &host,
-            &mut conn,
-            app_url,
-        )?;
+    if let Some(sent_at) = sent_at {
+        let set_password_url = app_url
+            .join(&scheme, &host, "/set-password/")
+            .inspect_err(|e| {
+                ft_sdk::println!("auth.wasm: failed to join url: {:?}", e);
+            })?;
 
-        let name = data.name.unwrap_or_else(|| email.clone());
-
-        email_auth::handlers::forgot_password::send_reset_password_email(
+        check_expired_and_send_reset_link(
+            set_password_url,
+            sent_at,
+            &data,
+            user_id.clone(),
             email,
-            name,
-            &reset_link,
-            &config,
+            &mut conn,
+            config,
         )?;
-
-        return Err(ft_sdk::single_error(
-            "code",
-            "Confirmation code expired. A new link has been sent to your email address.",
-        )
-        .into());
     }
 
     let data = {
@@ -101,11 +81,11 @@ fn key_expired(sent_at: chrono::DateTime<chrono::Utc>) -> bool {
 }
 
 fn validate_email_and_password(
-    email: &str,
+    email: &Option<String>,
     new_password: &str,
     new_password2: &str,
 ) -> Result<(), ft_sdk::Error> {
-    if !validator::ValidateEmail::validate_email(&email) {
+    if email.is_some() && !validator::ValidateEmail::validate_email(email.as_ref().unwrap()) {
         return Err(ft_sdk::single_error("email", "Invalid email format.").into());
     }
 
@@ -122,4 +102,85 @@ fn validate_email_and_password(
     }
 
     Ok(())
+}
+
+/// Get logged in user or user with the reset code
+fn get_user(
+    conn: &mut ft_sdk::Connection,
+    sid: ft_sdk::Cookie<{ ft_sdk::auth::SESSION_KEY }>,
+    reset_code: Option<String>,
+) -> Result<(ft_sdk::UserId, ft_sdk::auth::ProviderData), ft_sdk::Error> {
+    let user = ft_sdk::auth::ud(sid, conn).ok().flatten().map(|v| v.id);
+
+    let res = if let Some(user_id) = user {
+        // if user is logged in, we can use the user_id to get the user data
+        ft_sdk::auth::provider::user_data_by_id(
+            conn,
+            email_auth::PROVIDER_ID,
+            &ft_sdk::UserId(user_id),
+        )
+        .map(|v| (ft_sdk::UserId(user_id), v))
+    } else {
+        // if user is not logged in, we can use the code to get the user data
+        let reset_code = reset_code
+            .ok_or_else(|| ft_sdk::single_error("code", "Invalid reset code and not logged in."))?;
+
+        ft_sdk::auth::provider::user_data_by_custom_attribute(
+            conn,
+            email_auth::PROVIDER_ID,
+            email_auth::PASSWORD_RESET_CODE_KEY,
+            &reset_code,
+        )
+    };
+
+    match res {
+        Ok(v) => Ok(v),
+        Err(ft_sdk::auth::UserDataError::NoDataFound) => {
+            Err(ft_sdk::single_error("code", "Invalid reset code or not logged in.").into())
+        }
+        Err(e) => Err(e.into()),
+    }
+}
+
+fn check_expired_and_send_reset_link(
+    set_password_url: String,
+    sent_at: i64,
+    data: &ft_sdk::auth::ProviderData,
+    user_id: ft_sdk::UserId,
+    email: Option<String>,
+    conn: &mut ft_sdk::Connection,
+    config: crate::Config,
+) -> Result<(), ft_sdk::Error> {
+    let sent_at = chrono::DateTime::from_timestamp_nanos(sent_at);
+
+    if !key_expired(sent_at) {
+        return Ok(());
+    }
+
+    let email = email.ok_or_else(|| {
+        ft_sdk::single_error("email", "Email is required if you're not logged in.")
+    })?;
+
+    let reset_link = email_auth::handlers::forgot_password::generate_new_reset_key(
+        data.clone(),
+        &user_id,
+        &email,
+        set_password_url,
+        conn,
+    )?;
+
+    let name = data.name.clone().unwrap_or_else(|| email.to_string());
+
+    email_auth::handlers::forgot_password::send_reset_password_email(
+        email.to_string(),
+        name,
+        &reset_link,
+        &config,
+    )?;
+
+    Err(ft_sdk::single_error(
+        "code",
+        "Confirmation code expired. A new link has been sent to your email address.",
+    )
+    .into())
 }

--- a/email-auth-provider/src/lib.rs
+++ b/email-auth-provider/src/lib.rs
@@ -58,3 +58,27 @@ pub fn wasm_handler_link(
         app_url = app_url.unwrap_or_default().trim_end_matches('/'),
     )
 }
+
+/// Same as `ft_sdk::Scheme`
+/// - https only when host: 127.0.0.1
+struct HTTPSScheme(pub ft_sdk::Scheme);
+
+impl ft_sdk::FromRequest for HTTPSScheme {
+    fn from_request(req: &http::Request<serde_json::Value>) -> Result<Self, ft_sdk::Error> {
+        let host = ft_sdk::Host::from_request(req)?;
+
+        if host.without_port() == "127.0.0.1" {
+            Ok(HTTPSScheme(ft_sdk::Scheme::Http))
+        } else {
+            Ok(HTTPSScheme(ft_sdk::Scheme::Https))
+        }
+    }
+}
+
+impl std::ops::Deref for HTTPSScheme {
+    type Target = ft_sdk::Scheme;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}

--- a/lets-auth-template.fifthtry.site/index.ftd
+++ b/lets-auth-template.fifthtry.site/index.ftd
@@ -28,7 +28,11 @@ link: /only-logged-in/
 
 -- ftd.text: login
 if: { lets-auth.user == NULL }
-link: /-/auth/signin/
+link: $ftd.app-url(path=/signin/, app = lets-auth)
+
+-- ftd.text: forgot password
+if: { lets-auth.user == NULL }
+link: $ftd.app-url(path=/forgot-password/, app = lets-auth)
 
 
 

--- a/lets-auth-template.fifthtry.site/lets-auth.ftd
+++ b/lets-auth-template.fifthtry.site/lets-auth.ftd
@@ -1,7 +1,7 @@
 -- import: lets-auth.fifthtry.site/actions/dummy/create-account
 
 -- import: lets-auth.fifthtry.site as _
-export: signin-page, signup-page, user, forgot-password-url, user-details, set-password-page, forgot-password-success-url, set-password-url, forgot-password-page, auth-page, sign-up-url, sign-in-url, create-account-confirmation-subject, create-account-confirmation-html, create-account-confirmation-text, reset-password-subject, reset-password-text, reset-password-html, super-user-id, is-personal-site
+export: signin-page, signup-page, user, forgot-password-url, user-details, set-password-page, forgot-password-success-url, set-password-url, forgot-password-page, auth-page, sign-up-url, sign-in-url, create-account-confirmation-subject, create-account-confirmation-html, create-account-confirmation-text, reset-password-subject, reset-password-text, reset-password-html, super-user-id, is-personal-site, forgot-password-success-page
 
 ;; Lines starting with ";;" are comments. Changing these will have no effect.
 ;; Feel free to delete these lines once you've read them.

--- a/lets-auth.fifthtry.site/actions/dummy/create-account.ftd
+++ b/lets-auth.fifthtry.site/actions/dummy/create-account.ftd
@@ -17,10 +17,11 @@ ftd.string-field $password:
 ftd.string-field $password2:
 ftd.boolean-field $accept_terms:
 ftd.string-field $next:
+string action_url: $ftd.app-url(path=/email_auth_provider/create-account/)
 js: $assets.files.actions.dummy.alert.js
 
 show_alert(
-    "/-/auth/create-account/",
+    action_url,
     name,
     email,
     username,
@@ -42,10 +43,11 @@ ftd.string-field $password2:
 ftd.boolean-field $accept_terms:
 ftd.string-field $next:
 string code:
+string action_url: $ftd.app-url(path=/email_auth_provider/create-account/)
 js: $assets.files.actions.dummy.alert.js
 
 show_alert(
-    "/-/auth/create-account/",
+    action_url,
     name,
     email,
     username,

--- a/lets-auth.fifthtry.site/actions/dummy/create-account.ftd
+++ b/lets-auth.fifthtry.site/actions/dummy/create-account.ftd
@@ -29,3 +29,29 @@ show_alert(
     accept_terms,
     next
 )
+
+;; Note: unused in this package.
+;; This is provided to support create account flows where the user is pre verified and they just want to give basic info and set password.
+;; The `code` should be used for verifying genuine requests
+-- void create-account-with-code(name, email, username, password, password2, accept_terms, next, code):
+ftd.string-field $name:
+ftd.string-field $email:
+ftd.string-field $username:
+ftd.string-field $password:
+ftd.string-field $password2:
+ftd.boolean-field $accept_terms:
+ftd.string-field $next:
+string code:
+js: $assets.files.actions.dummy.alert.js
+
+show_alert(
+    "/-/auth/create-account/",
+    name,
+    email,
+    username,
+    password,
+    password2,
+    accept_terms,
+    next,
+    code
+)

--- a/lets-auth.fifthtry.site/actions/dummy/forgot-password.ftd
+++ b/lets-auth.fifthtry.site/actions/dummy/forgot-password.ftd
@@ -1,22 +1,15 @@
 -- ftd.string-field $username-or-email: username-or-email
 
 -- ftd.string-field $next: next
-value: *$lets-auth.forgot-password-success-url
+value: $ftd.app-url(path = /forgot-password-success/, app = lets-auth)
 
-;; The user will visit this page from their email to reset their password
--- ftd.string-field $set-password-route: set-password-route
-value: *$lets-auth.set-password-url
-
-
--- void submit-values(username_or_email):
+-- void forgot-password(username_or_email, next):
 ftd.string-field username_or_email:
-ftd.string-field next: $next
-ftd.string-field set_password_route: $set-password-route
+ftd.string-field $next: $next
 js: $assets.files.actions.dummy.alert.js
 
 show_alert(
     "/-/auth/forgot-password/",
     username_or_email,
-    next,
-    set_password_route
+    next
 )

--- a/lets-auth.fifthtry.site/actions/dummy/set-password.ftd
+++ b/lets-auth.fifthtry.site/actions/dummy/set-password.ftd
@@ -2,15 +2,14 @@
 -- ftd.string-field $new-password2: new-password2
 
 -- ftd.string-field next: next
-value: $lets-auth.sign-in-url
+value: $ftd.app-url(path = /signin/?reset-success=true)
 
--- void submit-values(new_password, new_password2, email, code, spr):
+-- void set-password(new_password, new_password2, email, code, next):
 ftd.string-field new_password:
 ftd.string-field new_password2:
 ftd.string-field email:
 ftd.string-field code:
-ftd.string-field spr:
-ftd.string-field next: $next
+ftd.string-field next:
 js: $assets.files.actions.dummy.alert.js
 
 show_alert(
@@ -19,6 +18,5 @@ show_alert(
     new_password2,
     email,
     code,
-    spr,
     next,
 )

--- a/lets-auth.fifthtry.site/actions/forgot-password.ftd
+++ b/lets-auth.fifthtry.site/actions/forgot-password.ftd
@@ -1,24 +1,17 @@
--- import: lets-talk-template.fifthtry.site/data/urls
-
 -- ftd.string-field $username-or-email: username-or-email
 
+;; NOTE: can't directly use `lets-auth.forgot-password-success-url`. There's a
+;; bug that does send `next` to the serve if we do that.
 -- ftd.string-field $next: next
-value: *$urls.forgot-password-success
+value: $ftd.app-url(path = /forgot-password-success/, app = lets-auth)
 
-;; The user will visit this page from their email to reset their password
--- ftd.string-field $set-password-route: set-password-route
-value: *$urls.set-password
-
-
--- void submit-values(username_or_email):
+-- void forgot-password(username_or_email, next):
 ftd.string-field username_or_email:
-ftd.string-field next: $next
-ftd.string-field set_password_route: $set-password-route
+ftd.string-field $next:
 string action_url: $ftd.app-url(path=/email_auth_provider/forgot-password/)
 
 ftd.submit_form(
     action_url,
     username_or_email,
-    next,
-    set_password_route
+    next
 )

--- a/lets-auth.fifthtry.site/actions/set-password.ftd
+++ b/lets-auth.fifthtry.site/actions/set-password.ftd
@@ -1,18 +1,15 @@
--- import: lets-talk-template.fifthtry.site/data/urls
-
 -- ftd.string-field $new-password: new-password
 -- ftd.string-field $new-password2: new-password2
 
 -- ftd.string-field next: next
-value: $urls.sign-in
+value: $ftd.app-url(path = /signin/?reset-success=true)
 
--- void submit-values(new_password, new_password2, email, code, spr):
+-- void set-password(new_password, new_password2, email, code, next):
 ftd.string-field new_password:
 ftd.string-field new_password2:
 ftd.string-field email:
 ftd.string-field code:
-ftd.string-field spr:
-ftd.string-field next: $next
+ftd.string-field next:
 string action_url: $ftd.app-url(path=/email_auth_provider/set-password/)
 
 ftd.submit_form(
@@ -21,6 +18,5 @@ ftd.submit_form(
     new_password2,
     email,
     code,
-    spr,
     next,
 )

--- a/lets-auth.fifthtry.site/actions/signup.ftd
+++ b/lets-auth.fifthtry.site/actions/signup.ftd
@@ -42,10 +42,11 @@ ftd.string-field $password2:
 ftd.boolean-field $accept_terms:
 ftd.string-field $next:
 string code:
+string action_url: $ftd.app-url(path=/email_auth_provider/create-account/)
 js: $assets.files.actions.dummy.alert.js
 
 show_alert(
-    "/-/auth/create-account/",
+    action_url,
     name,
     email,
     username,

--- a/lets-auth.fifthtry.site/actions/signup.ftd
+++ b/lets-auth.fifthtry.site/actions/signup.ftd
@@ -29,3 +29,29 @@ ftd.submit_form(
     accept_terms,
     next
 )
+
+;; Note: unused in this package.
+;; This is provided to support create account flows where the user is pre verified and they just want to give basic info and set password.
+;; The `code` should be used for verifying genuine requests
+-- void create-account-with-code(name, email, username, password, password2, accept_terms, next, code):
+ftd.string-field $name:
+ftd.string-field $email:
+ftd.string-field $username:
+ftd.string-field $password:
+ftd.string-field $password2:
+ftd.boolean-field $accept_terms:
+ftd.string-field $next:
+string code:
+js: $assets.files.actions.dummy.alert.js
+
+show_alert(
+    "/-/auth/create-account/",
+    name,
+    email,
+    username,
+    password,
+    password2,
+    accept_terms,
+    next,
+    code
+)

--- a/lets-auth.fifthtry.site/assets/mail.svg
+++ b/lets-auth.fifthtry.site/assets/mail.svg
@@ -1,0 +1,39 @@
+<svg width="60" height="59" viewBox="0 0 60 59" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_d_180_4787)">
+<rect x="1.85156" y="0.35144" width="50.2971" height="50.2971" rx="5.02971" fill="#2B2B2B" shape-rendering="crispEdges"/>
+<g clip-path="url(#clip0_180_4787)">
+<rect x="12" y="20.5626" width="29.9858" height="20.393" rx="1" fill="#3D854C"/>
+<path d="M38.3417 41.6654H15.1777V11.4765H33.911L38.3417 16.1109V41.6654Z" fill="#EBE8E5"/>
+<path opacity="0.1" d="M33.9111 11.4765V16.042L38.3418 16.1109L33.9111 11.4765Z" fill="#292A2E"/>
+<path d="M12 21.5073C12 21.1059 12.4492 20.8681 12.7812 21.0939L40.6427 40.0422C41.0498 40.319 40.8539 40.9556 40.3615 40.9556H12.5C12.2239 40.9556 12 40.7318 12 40.4556V21.5073Z" fill="#489D5A"/>
+<g filter="url(#filter1_d_180_4787)">
+<path d="M42 21.5073C42 21.1059 41.5508 20.8681 41.2188 21.0939L13.3573 40.0422C12.9502 40.319 13.1461 40.9556 13.6385 40.9556H41.5C41.7761 40.9556 42 40.7318 42 40.4556V21.5073Z" fill="#4BA45E"/>
+</g>
+</g>
+</g>
+<defs>
+<filter id="filter0_d_180_4787" x="0.851562" y="0.35144" width="58.2969" height="58.2971" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="3" dy="4"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_180_4787"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_180_4787" result="shape"/>
+</filter>
+<filter id="filter1_d_180_4787" x="6.1377" y="21.0065" width="36.8623" height="27.9491" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-3" dy="4"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_180_4787"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_180_4787" result="shape"/>
+</filter>
+<clipPath id="clip0_180_4787">
+<rect x="12" y="10.8514" width="30" height="30" rx="1" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/lets-auth.fifthtry.site/config.ftd
+++ b/lets-auth.fifthtry.site/config.ftd
@@ -1,7 +1,6 @@
+;; WARN: any variable that has value `ftd.app-url()` does not work with `ftd.json`
 -- ftd.json:
 email-sender-name: $lets-auth.email-sender-name
 email-reply-to: $lets-auth.email-reply-to
-sign-in-url: $lets-auth.sign-in-url
-sign-up-url: $lets-auth.sign-up-url
 super-user-id: $lets-auth.super-user-id
 is-personal-site: $lets-auth.is-personal-site

--- a/lets-auth.fifthtry.site/forgot-password-success.ftd
+++ b/lets-auth.fifthtry.site/forgot-password-success.ftd
@@ -1,0 +1,1 @@
+-- lets-auth.forgot-password-success-page:

--- a/lets-auth.fifthtry.site/forgot-password.ftd
+++ b/lets-auth.fifthtry.site/forgot-password.ftd
@@ -1,0 +1,4 @@
+-- import: lets-auth.fifthtry.site/actions/forgot-password
+
+-- lets-auth.forgot-password-page:
+action: forgot-password

--- a/lets-auth.fifthtry.site/index.ftd
+++ b/lets-auth.fifthtry.site/index.ftd
@@ -12,6 +12,9 @@ export: set-password-page
 -- import: lets-auth.fifthtry.site/ui/forgot-password as _
 export: forgot-password-page
 
+-- import: lets-auth.fifthtry.site/ui/forgot-password-success as _
+export: forgot-password-success-page
+
 -- import: lets-auth.fifthtry.site/ui/auth-page as _
 export: auth-page
 
@@ -159,3 +162,7 @@ if: { lets-auth.user != NULL }
 -- ftd.text: login
 if: { lets-auth.user == NULL }
 link: $ftd.app-url(path=/signin/)
+
+-- ftd.text: forgot password
+if: { lets-auth.user == NULL }
+link: $ftd.app-url(path=/forgot-password/)

--- a/lets-auth.fifthtry.site/index.ftd
+++ b/lets-auth.fifthtry.site/index.ftd
@@ -6,7 +6,7 @@ export: signin-page
 -- import: lets-auth.fifthtry.site/ui/signup as _
 export: signup-page
 
--- import: lets-auth.fifthtry.site/ui/reset-password as _
+-- import: lets-auth.fifthtry.site/ui/set-password as _
 export: set-password-page
 
 -- import: lets-auth.fifthtry.site/ui/forgot-password as _

--- a/lets-auth.fifthtry.site/set-password.ftd
+++ b/lets-auth.fifthtry.site/set-password.ftd
@@ -1,0 +1,19 @@
+-- import: lets-auth.fifthtry.site/actions/set-password
+-- import: fastn/processors as pr
+
+-- optional string code:
+$processor$: pr.request-data
+
+-- optional string email:
+$processor$: pr.request-data
+
+-- ftd.string-field email-field: email
+value: $email
+
+-- ftd.string-field code-field: code
+value: $code
+
+-- lets-auth.set-password-page:
+action: set-password
+email: $email-field
+code: $code-field

--- a/lets-auth.fifthtry.site/signin.ftd
+++ b/lets-auth.fifthtry.site/signin.ftd
@@ -1,7 +1,14 @@
 -- import: lets-auth.fifthtry.site/actions/signin
+-- import: fastn/processors as pr
+
+;; User comes to the signin page after they have changed their password with
+;; this value set to true
+-- boolean reset-success: false
+$processor$: pr.request-data
 
 -- ftd.temporary-redirect: /
 if: { lets-auth.user != NULL }
 
 -- lets-auth.signin-page:
 action: signin
+reset-success: $reset-success

--- a/lets-auth.fifthtry.site/ui/forgot-password-success.ftd
+++ b/lets-auth.fifthtry.site/ui/forgot-password-success.ftd
@@ -1,0 +1,20 @@
+-- component forgot-password-success-page:
+
+-- lets-auth.auth-page: Recover Password
+
+-- ftd.image:
+src: $assets.files.assets.mail.svg
+fit: cover
+
+-- ds.copy-large: We've sent instructions to reset your password to **your registered email**.
+align: center
+
+-- ds.primary-button: Login
+width: full
+radius: curved
+link: $lets-auth.sign-in-url
+
+
+-- end: lets-auth.auth-page
+
+-- end: forgot-password-success-page

--- a/lets-auth.fifthtry.site/ui/forgot-password.ftd
+++ b/lets-auth.fifthtry.site/ui/forgot-password.ftd
@@ -10,7 +10,7 @@ module action: forgot-password
     placeholder: Enter username or email address
 
 	-- ds.primary-button: Send Reset Link
-	$on-click$: $forgot-password-page.action.submit-values(username_or_email = $forgot-password-page.action.username-or-email)
+	$on-click$: $forgot-password-page.action.forgot-password(username_or_email = $forgot-password-page.action.username-or-email, $next = $forgot-password-page.action.next)
 	width: full
 	radius: curved
 

--- a/lets-auth.fifthtry.site/ui/set-password.ftd
+++ b/lets-auth.fifthtry.site/ui/set-password.ftd
@@ -4,7 +4,6 @@
 module action: set-password
 ftd.string-field email:
 ftd.string-field code:
-ftd.string-field spr:
 
 -- lets-auth.auth-page: Reset Your Password
 
@@ -18,8 +17,16 @@ ftd.string-field spr:
     type: password
     placeholder: Confirm your new password
 
+    -- ds.copy-small: $set-password-page.code.error
+    if: { set-password-page.code.error != NULL }
+    color: $ds.colors.error.text
+
+    -- ds.copy-small: $set-password-page.email.error
+    if: { set-password-page.email.error != NULL }
+    color: $ds.colors.error.text
+
 	-- ds.primary-button: Change Password
-	$on-click$: $set-password-page.action.submit-values(new_password = $set-password-page.action.new-password, new_password2 = $set-password-page.action.new-password2, code = $set-password-page.code, email = $set-password-page.email, spr = $set-password-page.spr)
+	$on-click$: $set-password-page.action.set-password(new_password = $set-password-page.action.new-password, new_password2 = $set-password-page.action.new-password2, code = $set-password-page.code, email = $set-password-page.email, next = $set-password-page.action.next)
 	width: full
 	radius: curved
 

--- a/lets-auth.fifthtry.site/ui/signin.ftd
+++ b/lets-auth.fifthtry.site/ui/signin.ftd
@@ -3,8 +3,20 @@
 -- component signin-page:
 caption title: Sign in
 module action: signin
+boolean reset-success:
 
 -- lets-auth.auth-page: Sign in
+
+    -- ds.row:
+    if: { signin-page.reset-success == true }
+    spacing: $ds.spaces.vertical-gap.small
+    inset: $ds.spaces.inset-square.small
+    wrap: true
+
+        -- ds.copy-regular: Your password has been changed. Please sign in again.
+        width: hug-content
+
+    -- end: ds.row
 
     -- ds.form-field: Username or email address
     $field: $signin-page.action.username-or-email

--- a/lets-auth.fifthtry.site/ui/signin.ftd
+++ b/lets-auth.fifthtry.site/ui/signin.ftd
@@ -31,9 +31,9 @@ module action: signin
 
     -- end: ds.row
 
-        -- ds.link: Forgot password?
-        color: $ds.colors.accent.primary
-        link: $lets-auth.forgot-password-url
+    -- ds.link: Forgot password?
+    color: $ds.colors.accent.primary
+    link: $lets-auth.forgot-password-url
 
 -- end: lets-auth.auth-page
 


### PR DESCRIPTION
fifthtry.com has a special signup flow where it used a `code` to create pre-verified accounts (users don't get a verification email on their account). This might be useful for other websites that use this package too so we include that action here as well.

The action is not used anywhere in this package. Users of this package should decide how/if they want to use it.